### PR TITLE
Make sure we link to libmesos on OSX

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -30,6 +30,7 @@
 
 {port_envs, [
  	{"(linux|solaris)", "LDFLAGS", "$LDFLAGS -lstdc++ /usr/local/lib/libmesos.so"},
+ 	{"(darwin)", "LDFLAGS", "$LDFLAGS -lstdc++ /usr/local/lib/libmesos.dylib"},
 	{"CXXFLAGS", "$CXXFLAGS -Wall -O2 -static -std=c++11 -I/usr/local/include -I/usr/local/include/mesos -L/usr/local/lib -L/usr/lib "}]
 }.
 


### PR DESCRIPTION
We weren't linking to libmesos on OSX, so whenever I tried to load the thing, it crashed with missing symbol errors.

With this change, it links and now actually runs!
