### PR TITLE
Link Mesos as shared lib

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -76,18 +76,20 @@ sudo apt-get install libprotobuf-dev protobuf-compiler
 
 ```
 git clone .....
-cd erlang-mesos
+cd mesos-executor-bindings
 ```
 
-Get the project dependancies
+Get the project dependencies
 
 ```
 ./rebar get-deps
 ```
 
-Compile the application including the generated modules from the .proto file
+Compile the application including the generated modules from the .proto file (assuming Mesos is installed in /usr/local)
 
 ```
+export CXXFLAGS="-I/usr/local/include"
+export LDFLAGS="-L/usr/local/lib"
 ./rebar compile
 ```
 

--- a/rebar.config
+++ b/rebar.config
@@ -29,8 +29,8 @@
 {port_sources, ["c_src/*.c", "c_src/*.cpp"]}.
 
 {port_envs, [
- 	{"(linux|solaris)", "LDFLAGS", "$LDFLAGS -lstdc++ /usr/local/lib/libmesos.so"},
-	{"CXXFLAGS", "$CXXFLAGS -Wall -O2 -static -std=c++11 -I/usr/local/include -I/usr/local/include/mesos -L/usr/local/lib -L/usr/lib "}]
+ 	{"(linux|solaris|darwin)", "LDFLAGS", "$LDFLAGS -lstdc++ -lmesos"},
+	{"CXXFLAGS", "$CXXFLAGS -Wall -O2 -static -std=c++11"}]
 }.
 
 {port_specs, [{"priv/executor.so", ["c_src/executor.c", "c_src/*.cpp"]},   
@@ -59,6 +59,6 @@
  ]}.
 
 {deps, [
-    {gpb ,  ".*", {git, "git://github.com/tomas-abrahamsson/gpb.git", {tag, "3.17.2"}} },
+    {gpb ,  ".*", {git, "https://github.com/tomas-abrahamsson/gpb.git", {tag, "3.17.2"}} },
     {meck, ".*", {git, "https://github.com/eproxus/meck.git", {tag, "0.8.2"}}}
 ]}.


### PR DESCRIPTION
I was having issues with the references to /usr/local in the `rebar.config`. I took them out and replaced it with a reference to Mesos as a shared library using `-lmesos`. The only difference is that references to the Mesos libs are not in the config file but have to be set in the environment. This is more portable for things like the Jenkins server, where I set those in the job because I pull them in via Docker volume mount.
